### PR TITLE
remove extraneous args to use_ok

### DIFF
--- a/t/0-useme.t
+++ b/t/0-useme.t
@@ -5,7 +5,7 @@
 use strict;
 use Test::More tests => 2;
 
-use_ok('Unicode::Unihan', 'use');
+use_ok('Unicode::Unihan');
 is(ref(Unicode::Unihan->new) => 'Unicode::Unihan', 'class');
 
 __END__


### PR DESCRIPTION
Additional arguments to use_ok are not a test name, but arguments passed to the module's import method. Newer versions of perl will throw errors on these unhandled arguments.